### PR TITLE
customization/acpi: add section about qemu-guest-agent

### DIFF
--- a/docs/setup/customization/ACPI.md
+++ b/docs/setup/customization/ACPI.md
@@ -63,4 +63,8 @@ May 24 14:30:20 localhost systemd[1]: acpid.service: Deactivated successfully.
 May 24 14:30:20 localhost systemd[1]: Stopped ACPI event daemon.
 ```
 
+## qemu-guest-agent
+
+Beginning with Flatcar major release 3402, qemu-guest-agent is part of all images and can handle certain lifecycle operations without acpid. The agent service will automatically be enabled if a virtio-port with the name `org.qemu.guest_agent.0` is detected. For Openstack it is necessary to launch the instance with `hw_qemu_guest_agent=yes` set.
+
 [butane]: ../../provisioning/ignition/specification/#ignition-v3


### PR DESCRIPTION
Qemu-guest-agent is used in some of the same contexts as acpid, so mention how this works, and the option needed for openstack instances.