### PR TITLE
fix mismatch in file names

### DIFF
--- a/docs/provisioning/cl-config/examples.md
+++ b/docs/provisioning/cl-config/examples.md
@@ -81,7 +81,7 @@ Using a higher number of rounds will help create more secure passwords, but give
 ```yaml
 storage:
   files:
-    - path: /opt/file1
+    - path: /opt/file
       filesystem: root
       contents:
         inline: Hello, world!


### PR DESCRIPTION
Fixed small mismatch between the file name in the config file and its reference in the description below it.