### PR TITLE
Update link to chromium disk layout

### DIFF
--- a/docs/reference/developer-guides/sdk-disk-partitions.md
+++ b/docs/reference/developer-guides/sdk-disk-partitions.md
@@ -24,7 +24,7 @@ Flatcar Container Linux is designed to be reliably updated via a continuous stre
 For more information, [read more about the disk layout][chromium disk format] used by Chromium and ChromeOS, which inspired the layout used by Flatcar Container Linux.
 
 [OEM docs]: ../../installing/community-platforms/notes-for-distributors
-[chromium disk format]: http://www.chromium.org/chromium-os/chromiumos-design-docs/disk-format
+[chromium disk format]: https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md
 
 ## Mounted filesystems
 


### PR DESCRIPTION
# Update link to chromium disk layout

The prior chromium site complains that the link is outdated and should be updated.

## How to use

Open the new URL :-)

## Testing done

Checked the new URL to be working and that it show the expected content. 

I suppose the following template items would not be relevant for this kind of change, right?

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
