### PR TITLE
hetzner: Add link to GitHub repo

### DIFF
--- a/docs/installing/cloud/aws-ec2.md
+++ b/docs/installing/cloud/aws-ec2.md
@@ -225,6 +225,20 @@ Read more about using Terraform and Flatcar [here](../../provisioning/terraform/
 The following Terraform v0.13 module may serve as a base for your own setup.
 It will also take care of registering your SSH key at AWS EC2 and managing the network environment with Terraform.
 
+You can clone the setup from the [Flatcar Terraform examples repository](https://github.com/flatcar/flatcar-terraform/tree/main/aws) or create the files manually as we go through them and explain each one.
+
+```
+git clone https://github.com/flatcar/flatcar-terraform.git
+# From here on you could directly run it, TLDR:
+cd aws
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+terraform init
+# Edit the server configs or just go ahead with the default example
+terraform plan
+terraform apply
+```
+
 Start with a `aws-ec2-machines.tf` file that contains the main declarations:
 
 ```

--- a/docs/installing/cloud/azure.md
+++ b/docs/installing/cloud/azure.md
@@ -362,6 +362,21 @@ Read more about using Terraform and Flatcar [here](../../provisioning/terraform/
 
 The following Terraform v0.13 module may serve as a base for your own setup.
 
+You can clone the setup from the [Flatcar Terraform examples repository](https://github.com/flatcar/flatcar-terraform/tree/main/azure) or create the files manually as we go through them and explain each one.
+
+```
+git clone https://github.com/flatcar/flatcar-terraform.git
+# From here on you could directly run it, TLDR:
+cd azure
+export ARM_SUBSCRIPTION_ID="<azure_subscription_id>"
+export ARM_TENANT_ID="<azure_subscription_tenant_id>"
+export ARM_CLIENT_ID="<service_principal_appid>"
+terraform init
+# Edit the server configs or just go ahead with the default example
+terraform plan
+terraform apply
+```
+
 Start with a `azure-vms.tf` file that contains the main declarations:
 
 ```

--- a/docs/installing/cloud/digitalocean.md
+++ b/docs/installing/cloud/digitalocean.md
@@ -204,6 +204,19 @@ Read more about using Terraform and Flatcar [here](../../provisioning/terraform/
 The following Terraform v0.13 module may serve as a base for your own setup.
 It will also take care of registering your SSH key at Digital Ocean and creating a custom image.
 
+You can clone the setup from the [Flatcar Terraform examples repository](https://github.com/flatcar/flatcar-terraform/tree/main/digitalocean) or create the files manually as we go through them and explain each one.
+
+```
+git clone https://github.com/flatcar/flatcar-terraform.git
+# From here on you could directly run it, TLDR:
+cd digitalocean
+export DIGITALOCEAN_TOKEN=...
+terraform init
+# Edit the server configs or just go ahead with the default example
+terraform plan
+terraform apply
+```
+
 Start with a `digitaloecan-droplets.tf` file that contains the main declarations:
 
 ```

--- a/docs/installing/cloud/equinix-metal.md
+++ b/docs/installing/cloud/equinix-metal.md
@@ -153,6 +153,19 @@ Read more about using Terraform and Flatcar [here](../../provisioning/terraform/
 
 The following Terraform v0.13 module may serve as a base for your own setup.
 
+You can clone the setup from the [Flatcar Terraform examples repository](https://github.com/flatcar/flatcar-terraform/tree/main/equinix-metal-aka-packet) or create the files manually as we go through them and explain each one.
+
+```
+git clone https://github.com/flatcar/flatcar-terraform.git
+# From here on you could directly run it, TLDR:
+cd equinix-metal-aka-packet
+export METAL_AUTH_TOKEN=...
+terraform init
+# Edit the server configs or just go ahead with the default example
+terraform plan
+terraform apply
+```
+
 Start with a `metal-machines.tf` file that contains the main declarations:
 
 ```

--- a/docs/installing/cloud/hetzner.md
+++ b/docs/installing/cloud/hetzner.md
@@ -213,3 +213,5 @@ terraform apply
 Log in via `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@IPADDRESS` with the printed IP address.
 
 When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the machine will be replaced.
+
+You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/hetzner).

--- a/docs/installing/cloud/hetzner.md
+++ b/docs/installing/cloud/hetzner.md
@@ -39,6 +39,19 @@ Read more about using Terraform and Flatcar [here](../../provisioning/terraform/
 The following Terraform v0.13 module may serve as a base for your own setup.
 It will also take care of registering your SSH key at Hetzner.
 
+You can clone the setup from the [Flatcar Terraform examples repository](https://github.com/flatcar/flatcar-terraform/tree/main/flatcar-terraform-hetzner) or create the files manually as we go through them and explain each one.
+
+```
+git clone https://github.com/flatcar/flatcar-terraform.git
+# From here on you could directly run it, TLDR:
+cd flatcar-terraform-hetzner
+export HCLOUD_TOKEN=...
+terraform init
+# Edit the server configs or just go ahead with the default example
+terraform plan
+terraform apply
+```
+
 Start with a `hetzner-machines.tf` file that contains the main declarations:
 
 ```
@@ -214,4 +227,4 @@ Log in via `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core
 
 When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the machine will be replaced.
 
-You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/hetzner).
+As mentined in the beginning, you can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/hetzner).


### PR DESCRIPTION
The link to the repo was missing for Hetzner.

Like with the other Terraform cloud provider docs, link to the repo at the end.
