### PR TITLE
nginx example: Use journald logging backend

### DIFF
--- a/docs/installing/_index.md
+++ b/docs/installing/_index.md
@@ -82,7 +82,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/bare-metal/booting-with-ipxe.md
+++ b/docs/installing/bare-metal/booting-with-ipxe.md
@@ -106,7 +106,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/bare-metal/booting-with-pxe.md
+++ b/docs/installing/bare-metal/booting-with-pxe.md
@@ -67,7 +67,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/bare-metal/installing-to-disk.md
+++ b/docs/installing/bare-metal/installing-to-disk.md
@@ -151,7 +151,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/aws-ec2.md
+++ b/docs/installing/cloud/aws-ec2.md
@@ -81,7 +81,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/azure.md
+++ b/docs/installing/cloud/azure.md
@@ -209,7 +209,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/digitalocean.md
+++ b/docs/installing/cloud/digitalocean.md
@@ -72,7 +72,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/equinix-metal.md
+++ b/docs/installing/cloud/equinix-metal.md
@@ -76,7 +76,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/gcp.md
+++ b/docs/installing/cloud/gcp.md
@@ -116,7 +116,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/openstack.md
+++ b/docs/installing/cloud/openstack.md
@@ -105,7 +105,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s

--- a/docs/installing/cloud/vmware.md
+++ b/docs/installing/cloud/vmware.md
@@ -128,7 +128,7 @@ systemd:
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/docker rm --force nginx1
-        ExecStart=/usr/bin/docker run --name nginx1 --pull always --net host docker.io/nginx:1
+        ExecStart=/usr/bin/docker run --name nginx1 --pull always --log-driver=journald --net host docker.io/nginx:1
         ExecStop=/usr/bin/docker stop nginx1
         Restart=always
         RestartSec=5s


### PR DESCRIPTION
The default Docker log backend is using json files and for long running processes they could easily fill up the disk.
Use the journald logging backend to benefit from truncating. The "none" backend is also an option but it makes "docker log ID" fail. The drawback with the journald backend is that it duplicates the system wide entries because we already have them from the systemd unit stdout.


## How to use


## Testing done

none