### PR TITLE
docs: fix a broken link to the style guide

### DIFF
--- a/docs/contribute/_index.md
+++ b/docs/contribute/_index.md
@@ -55,4 +55,4 @@ We happily accept accurate translations. Please send the documents as a pull req
 [flatcar-docs]: https://kinvolk.io/docs/flatcar-container-linux/latest/
 [help-wanted]: https://github.com/kinvolk/docs/issues?q=is%3Aopen+label%3Ahelp-wanted
 [pull-requests]: https://help.github.com/articles/using-pull-requests/
-[style]: STYLE
+[style]: docs

--- a/docs/contribute/docs.md
+++ b/docs/contribute/docs.md
@@ -259,4 +259,4 @@ Some file types are commonly identified with more than one file name extension. 
 [quickstart]: os/quickstart "Relative link from here to CoreOS Quick Start"
 [rfc2606s3]: https://tools.ietf.org/html/rfc2606#section-3
 [rfc5737]: https://tools.ietf.org/html/rfc5737
-[style]: STYLE "CoreOS Documentation Style"
+[style]: docs "CoreOS Documentation Style"


### PR DESCRIPTION
Fix a broke link https://www.flatcar.org/docs/latest/contribute/STYLE, which should be actually https://www.flatcar.org/docs/latest/contribute/docs.

Discussed during the Linux community meeting.