### PR TITLE
sdk-modifying-flatcar: update org name in container registry link

### DIFF
--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -675,7 +675,7 @@ Take a look at the [SDK bootstrap process](sdk-bootstrapping) to learn how to bu
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
 [github-flatcar]: https://github.com/flatcar
 [matrix]: https://app.element.io/#/room/#flatcar:matrix.org
-[ghcr-sdk]: https://github.com/orgs/flatcar-linux/packages
+[ghcr-sdk]: https://github.com/orgs/flatcar/packages
 [scripts]: https://github.com/flatcar/scripts
 [flatcar-releases]: https://www.flatcar-linux.org/releases/
 


### PR DESCRIPTION
The old link still works, but points to a page that doesn't have the SDK images.