### PR TITLE
Document Alpha 3535.0.0 changes for /etc overlay and flatcar-reset

### DIFF
--- a/docs/provisioning/ignition/_index.md
+++ b/docs/provisioning/ignition/_index.md
@@ -36,7 +36,7 @@ The lack of variable substitution in Ignition has an added benefit of leveling t
 
 ### When is Ignition executed
 
-On boot, GRUB checks the EFI System Partition for a file at `flatcar/first_boot` (or `coreos/first_boot` if the machine was updated from CoreOS CL) and sets `flatcar.first_boot=detected` if found. The `flatcar.first_boot` parameter is processed by a [systemd-generator] in the [initramfs] and if the parameter value is non-zero, the Ignition units are set as dependencies of `initrd.target`, causing Ignition to run. If the parameter is set to the special value `detected`, the `flatcar/first_boot` (or `coreos/first_boot`) file is deleted after Ignition runs successfully.
+On boot, GRUB checks the EFI System Partition for a file at `flatcar/first_boot` (or `coreos/first_boot` if the machine was updated from CoreOS CL) and sets `flatcar.first_boot=detected` if found. The `flatcar.first_boot` parameter is processed by a [systemd-generator] in the [initramfs] and if the parameter value is non-zero, the Ignition units are set as dependencies of `initrd.target`, causing Ignition to run. If the parameter is set to the special value `detected`, the `flatcar/first_boot` (or `coreos/first_boot`) file is deleted after Ignition runs successfully. You can schedule a re-run of Ignition with the `flatcar-reset` tool (available since Alpha 3535.0.0), which also takes care of cleaning up old rootfs state and keeping only the data from the rootfs you want to keep.
 
 Note that [PXE][supported-platforms] deployments don't use GRUB to boot, so `flatcar.first_boot=1` must be added to the boot arguments in order for Ignition to run. `detected` should not be specified so Ignition will not attempt to delete `flatcar/first_boot` (or `coreos/first_boot`).
 

--- a/docs/provisioning/ignition/boot-process.md
+++ b/docs/provisioning/ignition/boot-process.md
@@ -42,8 +42,41 @@ After all of the tasks in the initramfs complete, the machine pivots into user s
 
 ### Reprovisioning
 
-To trigger a new Ignition run, either manually set `flatcar.first_boot=1` as temporary kernel command line parameter in GRUB or create the flag file `touch /boot/flatcar/first_boot` (or `/boot/coreos/first_boot` if the machine was updated from CoreOS CL).
+To trigger a new Ignition run, you should use the `flatcar-reset` tool (available from Alpha 3535.0.0) for a (selective) cleanup of the root filesystem during the next boot. It takes care of cleaning up old state (e.g., files from the old configuration or any side effects such as state files) while keeping only the data you want to keep through the `--keep-paths` argument. The paths to keep can be specified as regular expressions. The machine ID can be kept through the `--keep-machine-id` argument (turning it into a kernel cmdline parameter because `/etc/machine-id` can't be preserved directly for systemd first boot semantics). It is also possible to specify that a local or a particular remote Ignition configuration should be used.
 
+When paths to keep are specified, only needed paths should be used and not those set up by the old Ignition config or side effects of it, to really discard the old configuration state. When a path specified is a directory, the contents are preserved as well because `MYPATH/.*` is automatically appended as an additional regular expression for paths to keep.
+To delete the contents of a directory but keep the directory itself, specify it as an equivalent regular expression in the form of `'^/etc/mypath'`, `'/etc/mypath$'`, `'/etc/mypat[h]'`, `'/etc/(mypath)'`, or `'(/etc/mypath)'`.
+
+The used regular expression language is that of `egrep`. Assuming you specified `/etc/mypath`, you can test which paths will be deleted with the following command (note the `-not`):
+
+```sh
+find / /etc -xdev -regextype egrep -not -regex '(/etc/mypath|/etc/mypath/.*)'
+```
+
+You can test which path will be kept with the following command (note the absence of `-not`):
+
+```sh
+find / /etc -xdev -regextype egrep -regex '(/etc/mypath|/etc/mypath/.*)'
+```
+
+Both `/` and `/etc` need to be specified because `/etc` is an overlay mount.
+
+Meaningful examples are:
+
+- `'/etc/ssh/ssh_host_.*'` to preserve SSH host keys
+- `/var/log` to preserve system logs
+- `/var/lib/docker` and `/var/lib/containerd` to preserve container state and images
+
+An example for selectively resetting the OS with retriggering Ignition while keeping SSH host keys, logs, and machine ID:
+
+```sh
+sudo flatcar-reset --keep-machine-id --keep-paths '/etc/ssh/ssh_host_.*' /var/log
+sudo systemctl reboot
+```
+
+#### Technical Details for Manual Ignition Re-runs
+
+Not recommended but possible is to either manually set `flatcar.first_boot=1` as temporary kernel command line parameter in GRUB or to create the flag file with `touch /boot/flatcar/first_boot` (or `/boot/coreos/first_boot` if the machine was updated from CoreOS CL).
 Be aware that if you changed the Ignition config in the mean time, old files not known to the new Ignition config will be kept, and any other runtime data, too.
 Systemd service presets are also not reevaluated automatically. This means that newly declared service units won't be enabled unless you also invalidate the machine ID or create the symlinks for the service targets.
 

--- a/docs/provisioning/terraform/_index.md
+++ b/docs/provisioning/terraform/_index.md
@@ -59,9 +59,12 @@ When using a template be careful to refer to the Terraform variables via `${vari
 Sometimes you want to take the declarative approach of Terraform but can't accept that nodes are destroyed and recreated for configuration changes.
 This is the case for nodes that have a manual or slow bring-up process, much data that can't be moved easily, or where the IP address should not change.
 
-Ignition can be told to run again through `touch /boot/flatcar/first_boot` but it [won't clean up any old state][boot-process].
-For that you have to reformat the root filesystem with Ignition to ensure that no old state is present.
-Persistent data should be stored on another partition.
+Ignition can be told to run again through `flatcar-reset` (available since Alpha 3535.0.0), which also takes care of cleaning up old rootfs state and keeping only the rootfs data you want to keep.
+
+### Reformatting
+
+Another alternative to `flatcar-reset` is to reformat the root filesystem with Ignition to ensure that no old state is present, or use cloud-provider [reinstall options like on Equinix Metal](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device#reinstall).
+Persistent data should be stored on another partition which should be set to be kept.
 
 We can also preserve the machine ID by setting it as kernel cmdline parameter (it must not be kept as file on the root filesystem because that prevents the systemd first-boot semantics to enable units through the preset Ignition creates).
 
@@ -96,7 +99,8 @@ storage:
 ```
 
 The final User Data needs to be stored on a place where modifications are allowed without destroying the node.
-A good option could be AWS S3 or other similar cloud storage solutions.
+For some Terraform providers it is directly possible to allow changes but that is not always the case.
+A good option then could be AWS S3 or other similar cloud storage solutions.
 The real User Data of the node is just an Ignition Config that references the external User Data:
 
 ```

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -285,6 +285,17 @@ update_engine_client -reset_status
 update_engine_client -check_for_update
 ```
 
+### Management of config files
+
+Since Alpha 3535.0.0 the OS config files under `/etc` are updated through the overlay mount as long as they are not modified.
+On boot any files in `/etc` that are the same as provided by the booted `/usr/share/flatcar/etc` default for the overlay mount on `/etc` are deleted to ensure that future updates of `/usr/share/flatcar/etc` are propagated. To opt out, create `/etc/.no-dup-update` in case you want to keep an unmodified config file as is or because you fear that a future Flatcar version may use the same file as you at which point your copy is cleaned up and any other future Flatcar changes would be applied.
+
+To find out the differences of your machine compared to the OS defaults, run:
+
+```sh
+sudo git diff --no-index /usr/share/flatcar/etc /etc
+```
+
 ### Configure a post-install update hook
 
 Sometimes you may want to run a custom action after update-engine wrote the new partition out.


### PR DESCRIPTION
- Document flatcar-reset tool
- Document the /etc overlay cleanup logic and how to opt-out

Later I'll also look into updating the Terraform example setup to make use of flatcar-reset.