### PR TITLE
Improve docs for flatcar-reset and the overlay

### DIFF
--- a/docs/provisioning/terraform/_index.md
+++ b/docs/provisioning/terraform/_index.md
@@ -61,6 +61,9 @@ This is the case for nodes that have a manual or slow bring-up process, much dat
 
 Ignition can be told to run again through `flatcar-reset` (available since Alpha 3535.0.0), which also takes care of cleaning up old rootfs state and keeping only the rootfs data you want to keep.
 
+A Terraform setup that runs `flatcar-reset` when the cloud instance userdata changes can be found in the [flatcar-terraform repository][example-repo].
+The list of paths in the rootfs to keep can be configured.
+
 ### Reformatting
 
 Another alternative to `flatcar-reset` is to reformat the root filesystem with Ignition to ensure that no old state is present, or use cloud-provider [reinstall options like on Equinix Metal](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device#reinstall).

--- a/docs/reference/developer-guides/sdk-disk-partitions.md
+++ b/docs/reference/developer-guides/sdk-disk-partitions.md
@@ -53,9 +53,7 @@ All stateful data, including container images, is stored within the read/write f
 
 The data stored on the root partition isn't manipulated by the update process. In return, we do our best to prevent you from modifying the data in /usr.
 
-Due to the unique disk layout of Flatcar Container Linux, an `rm -rf --one-file-system --no-preserve-root /` is an unsupported but valid operation to purge any OS data. On the next boot, the machine should just start from a clean state.
-
-To [re-provision][provisioning] the node after such cleanup, use `touch /boot/flatcar/first_boot` to trigger Ignition [to run once][boot process] again on the next boot (if the machine was updated from CoreOS Container Linux, you need to use `/boot/coreos/first_boot`).
+Due to the unique disk layout of Flatcar Container Linux, `umount -l /etc && rm -rf --one-file-system --no-preserve-root /` is an unsupported but valid operation to purge any OS data. On the next boot, the machine should just start from a clean state, but note that you should rather use the `flatcar-reset` tool for a proper reset, which also gives control of what data to keep.
 
 [provisioning]: ../../provisioning
 [boot process]: ../../provisioning/ignition/boot-process

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -296,6 +296,12 @@ To find out the differences of your machine compared to the OS defaults, run:
 sudo git diff --no-index /usr/share/flatcar/etc /etc
 ```
 
+You can also see what files got created under the real `/etc` with the following commands:
+
+```sh
+sudo unshare -m "umount /etc; ls -lahR /etc"
+```
+
 ### Configure a post-install update hook
 
 Sometimes you may want to run a custom action after update-engine wrote the new partition out.


### PR DESCRIPTION
- Mention terraform setup for flatcar-reset
    
    The updated terraform setup in
    https://github.com/flatcar/flatcar-terraform/pull/14 uses flatcar-reset
    to preserve wanted data in the rootfs.
- Document how to list the contents of the underlying real /etc
- Hint at flatcar-reset tool for removing rootfs state