### PR TITLE
update-stategies: Recommend to use flatcar-pxe-update-engine

### DIFF
--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -155,6 +155,8 @@ PXE/iPXE machines download a new copy of Flatcar Container Linux every time they
 
 An easy solution to this problem is to use iPXE and reference images [directly from the Flatcar Container Linux storage site][ipxe-boot-script]. The `alpha` URL is automatically pointed to the new version of Flatcar Container Linux as it is released.
 
+In case you never install to disk but only run the PXE image in memory, you would still need a manual reboot to switch to new versions. To address that, consider running the external tool [flatcar-pxe-update-engine](https://github.com/utilitywarehouse/flatcar-pxe-update-engine) for automatic reboots with locksmith as discussed in the sections above.
+
 ## Disable Automatic Updates
 
 If for a short time frame you want to temporarily disable update reboots, run `sudo systemctl stop update-engine locksmithd`, and when done, `sudo systemctl start update-engine locksmithd`.

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -1,5 +1,5 @@
 ---
-title: Reboot strategies on updates
+title: Update and reboot strategies
 description: How to configure when you Flatcar instances should reboot.
 weight: 30
 aliases:


### PR DESCRIPTION
- update-stategies: Rename the title to refect the content
- update-stategies: Recommend to use flatcar-pxe-update-engine
    
    The flatcar-pxe-update-engine project provides an update_engine
    replacement for PXE in-memory boots that don't install to disk.

I haven't tried flatcar-pxe-update-engine myself but it is actively maintained.