### PR TITLE
systemd: Document how to add custom shutdown actions

### DIFF
--- a/docs/setup/systemd/getting-started.md
+++ b/docs/setup/systemd/getting-started.md
@@ -157,6 +157,24 @@ ExecStartPost=/usr/bin/etcdctl set /domains/example.com/%H:%i running
 
 This gives us the flexibility to use a single unit file to announce multiple copies of the same container on a single machine (no port overlap) and on multiple machines (no hostname overlap).
 
+## Shutdown hooks
+
+While systemd allows to add custom hooks in `/usr/lib/systemd/system-shutdown/` that get run for `poweroff`/`halt`/`reboot`/`kexec` events, this path is not writable on Flatcar Container Linux. Therefore, regular units need to be used for running, e.g., a special cleanup action on shutdown:
+
+```ini
+[Unit]
+Description=Custom cleanup on shutdown
+DefaultDependencies=no
+After=final.target
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'echo bye; touch /bye'
+
+[Install]
+WantedBy=final.target
+```
+
 ## More information
 
 - [`systemd.service` Docs](http://www.freedesktop.org/software/systemd/man/systemd.service.html)


### PR DESCRIPTION
As discussed in https://github.com/flatcar/Flatcar/issues/65 the single path that systemd supports for shutdown hooks does not work for read- only images but we can use regular units to run custom shutdown actions. Document one way to do it (there are many other ways how to express this with systemd units).

## How to use


## Testing done

Tested this by enabling the unit and rebooting/powering off to check that the marker file appears and `bye` is in the journal.
