### PR TITLE
sysext: Document Upholds= for starting units

### DIFF
--- a/docs/provisioning/sysext/_index.md
+++ b/docs/provisioning/sysext/_index.md
@@ -28,11 +28,11 @@ An image must be named `NAME.raw` while a plain folder just uses `NAME` as name.
 The image can be a plain ext4 or btrfs filesystem image but squashfs images are a useful format to consider because besides the compression it offers, the `mksquashfs` tool simply takes a directory as input and doesn't need loop devices and mounting of an image file.
 
 Inside the image or folder structure there must be a file `usr/lib/extension-release.d/extension-release.NAME` with metadata used for version matching.
-The basic matching that has to be there is `ID=flatcar` plus one of `VERSION` or `SYSEXT_LEVEL`.
-If your binaries link against Flatcar's binaries under `/usr`, you must couple your sysext image to the Flatcar version by specyfing `VERSION=MAJOR.MINOR.PATH` to match the `/etc/os-release` version.
+The basic matching that needs to be there is `ID=flatcar` plus one of `VERSION_ID` or `SYSEXT_LEVEL`.
+If your binaries link against Flatcar's binaries under `/usr`, you must couple your sysext image to the Flatcar version by specyfing `VERSION_ID=MAJOR.MINOR.PATCH` in `extension-release.NAME` to match the `VERSION_ID` field from `/etc/os-release`.
 This means that the sysext image won't be loaded anymore after an OS update.
 Therefore, it is recommended that you try to use static binaries which lifts the requirement of having to couple the versions.
-In this case you can specify `SYSEXT_LEVEL=1.0` instead of `VERSION`.
+In this case you can specify `SYSEXT_LEVEL=1.0` instead of `VERSION_ID`.
 The matching semantics for `SYSEXT_LEVEL` are limited at the moment and the use case for bumping the version are not there yet.
 In summary, this is what you will normally write to the metadata file:
 


### PR DESCRIPTION
The recommended way to start sysext-shipped units is to use Upholds. Flatcar has a workaround for supporting target-wants symlinks but we may drop it in the future once upstream has support for reloading the units from disk to make Upholds work by default.

## How to use


## Testing done

