### PR TITLE
Document audit system usage

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -123,6 +123,7 @@ more.
  * [Using SELinux][selinux]
  * [Disabling SMT][disabling-smt]
  * [Enabling FIPS][enabling-fips]
+ * [Using the audit subsystem][audit-system]
 
 #### Debugging Flatcar
  * [Install debugging tools][debugging-tools]
@@ -214,6 +215,7 @@ APIs and troubleshooting guides for working with Flatcar Container Linux.
 [selinux]: setup/security/selinux
 [disabling-smt]: setup/security/disabling-smt
 [enabling-fips]: setup/security/fips
+[audit-system]: setup/security/audit
 [debugging-tools]: setup/debug/install-debugging-tools
 [btrfs]: setup/debug/btrfs-troubleshooting
 [system-log]: setup/debug/reading-the-system-log

--- a/docs/setup/security/audit.md
+++ b/docs/setup/security/audit.md
@@ -1,0 +1,40 @@
+---
+title: Setting up the Linux Auditing System
+linktitle: Set up audit
+description: Setting up the Linux Auditing System.
+weight: 20
+---
+
+On Flatcar Container Linux `audit-rules.service` loads the audit rules to set up the logging filters for the kernel messages.
+The `auditd.service` daemon to collect these logs does not run by default.
+
+# Enabling the standard rules or custom rules
+
+There is an ignore rule by default that suppresses the standard rules, which means that certain PAM audit messages are not shown.
+It is also important to remove this default ignore rule when setting up own rules, or otherwise they will be ignored, too.
+The following Butane Config will overwrite the default ignore rule:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/audit/rules.d/99-default.rules
+      overwrite: true
+      contents:
+        inline: |
+          # custom rules may go here, can be empty to use only the standard rules
+```
+
+# Enabling auditd
+
+In addition to the above, it may make sense to enable `auditd.service`, here a Butane Config snippet for that:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+systemd:
+  units:
+    - name: auditd.service
+      enabled: true
+```


### PR DESCRIPTION
The default ignore rule is tricky because it needs to be removed first when setting up own rules. We should at least document this. We can also tweak the defaults independently from having docs (as long as the docs are updated).
See https://github.com/flatcar/coreos-overlay/pull/2545

