### PR TITLE
sysext: Document setting up a symlink to /dev/null to disable default

### DIFF
--- a/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
+++ b/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
@@ -133,8 +133,13 @@ storage:
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
           SystemdCgroup = true
   directories:
-    - path: /etc/extensions/docker-flatcar
-    - path: /etc/extensions/containerd-flatcar
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
 ```
 
 While the system services have a `PATH` variable that prefers `/opt/bin/` by placing it first, you have to run the following command on every interactive login shell (also after `sudo` or `su`) to make sure you use the correct binaries.

--- a/docs/provisioning/sysext/_index.md
+++ b/docs/provisioning/sysext/_index.md
@@ -53,7 +53,7 @@ Upholds=docker.socket
 ## Supplying your sysext image from Ignition
 
 The following Butane Config YAML can be be transpiled to Ignition JSON and will download a custom Docker+containerd sysext image on first boot.
-It also takes care of disabling Torcx and future built-in Docker and containerd sysext images we plan to ship in Flatcar.
+It also takes care of disabling Torcx and future built-in Docker and containerd sysext images we plan to ship in Flatcar (to revert this, you can find the original target of the symlinks in `/usr/share/flatcar/etc/extensions/` - as said, this is not yet shipped).
 
 ```yaml
 variant: flatcar
@@ -65,9 +65,13 @@ storage:
       contents:
         source: https://myserver.net/mydocker.raw
     - path: /etc/systemd/system-generators/torcx-generator
-  directories:
-    - path: /etc/extensions/docker-flatcar
-    - path: /etc/extensions/containerd-flatcar
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
 ```
 
 After boot you can see it loaded in the output of the `systemd-sysext` command:


### PR DESCRIPTION
The original idea was that our future Docker/containerd sysext is set up in /usr/lib/extensions/ but support for this location got removed: https://github.com/systemd/systemd/commit/de862276eddbbe76b436213b4d427205356d1886 Now we would have to use our /etc overlay to enable the sysext image by default. The user opt-out entry to disable it was also in /etc and this won't work anymore. Instead, the user should directly overwrite the entry to let it point to /dev/null.

## How to use



## Testing done
