### PR TITLE
Strip unnecessary leading whitespace when fetching desired branch name

### DIFF
--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -33,7 +33,7 @@ Please note these resources might be outdated and only this page reflects the mo
 ```shell
 $ git clone https://github.com/flatcar/scripts.git
 $ cd scripts
-$ branch="$(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1)"
+$ branch="$(git branch -r -l | awk -F'/' '/origin/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1)"
 $ git checkout "$branch"
 $ ./run_sdk_container -t
 ```
@@ -95,7 +95,7 @@ At the same time, Alpha is not too far away from `main` so the risk of merge-tim
 Find the latest Alpha release branch:
 
 ```shell
-$ git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1
+$ git branch -r -l | awk -F'/' '/origin\/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1
 ```
 
 If the goal is to reproduce and to fix a bug of a release other than Alpha, it is recommended to base the work on the latest point release of the respective major version instead of Alpha. All currrently "active" major versions can be found at the top of the [releases][flatcar-releases] web page.

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -33,7 +33,7 @@ Please note these resources might be outdated and only this page reflects the mo
 ```shell
 $ git clone https://github.com/flatcar/scripts.git
 $ cd scripts
-$ branch="$(git branch -r -l | awk -F'/' '/origin/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1)"
+$ branch="$(git branch -r -l | awk -F'/' '/origin\/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1)"
 $ git checkout "$branch"
 $ ./run_sdk_container -t
 ```


### PR DESCRIPTION
# Strip unnecessary leading whitespace when fetching desired branch name

Hi. I came across the following documentation at https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/ and was contemplating whether it would be appropriate to modify the command ``branch="$(git branch -r -l | sed -n 's:origin/(flatcar-[0-9]+)$:\1:p' | sort | tail -n1)"`` to ``branch="$(git branch -r -l | awk -F'/' '/origin/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1)"`` instead. I noticed that the former version produces an unnecessary leading whitespace. Thank you for your attention

## How to use

Validate that the change made has no unforeseen side-effects. 



