### PR TITLE
Update architectures.md to fix https://github.com/flatcar/Flatcar/iss…

### DIFF
--- a/docs/setup/clusters/architectures.md
+++ b/docs/setup/clusters/architectures.md
@@ -36,7 +36,6 @@ systemd:
   units:
     - name: docker-tcp.socket
       enabled: true
-      mask: false
       contents: |
         [Unit]
         Description=Docker Socket for the API
@@ -48,14 +47,6 @@ systemd:
 
         [Install]
         WantedBy=sockets.target
-    - name: enable-docker-tcp.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Enable the Docker Socket for the API
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/systemctl enable docker-tcp.socket
 ```
 
 This file is used to provision your local Flatcar Container Linux machine on its first boot. This sets up and enables the Docker API, which is how you can use Docker on your laptop. The Docker CLI manages containers running within the VM, *not* on your personal operating system.


### PR DESCRIPTION
# Update architectures.md to fix [https://github.com/flatcar/Flatcar/iss…](https://github.com/flatcar/Flatcar/issues/260)

This pull request addresses the warning message that appears when using the current documentation and Butane config. The warning states that the 'enable-docker-tcp.service' unit is enabled but lacks an install section, rendering the enable command ineffective. The proposed changes in this pull request resolve this issue.


# Testing

![image](https://github.com/flatcar/flatcar-docs/assets/75043245/0ae62043-eee1-4f65-8db7-19ef8364b925)


