### PR TITLE
sysext: Add debugging commands

### DIFF
--- a/docs/provisioning/sysext/_index.md
+++ b/docs/provisioning/sysext/_index.md
@@ -184,4 +184,19 @@ systemd:
 This configuration will enable the `systemd-sysupdate.timer` unit that will check every 2-6 hours for a new Docker sysext image available from the latest release of [`sysext-bakery`][sysext-bakery].
 Use `arm64` instead of `x86-64` for arm64 machines.
 
+## Debugging
+
+You can list the contents of a systemd-sysext image like this (assuming an image without dm-verity):
+
+```
+sudo unshare -m sh -c "mount docker-compose-2.18.1.raw /tmp && cd /tmp && find ."
+# Remember that only the "usr" or "opt" folder will be used for the overlay
+```
+
+To get more information about found incompatibilities during merging, enable the debug output:
+
+```
+sudo SYSTEMD_LOG_LEVEL=debug systemd-sysext refresh
+```
+
 [sysext-bakery]: https://github.com/flatcar/sysext-bakery

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -305,7 +305,7 @@ sudo git diff --no-index /usr/share/flatcar/etc /etc
 You can also see what files got created under the real `/etc` with the following commands:
 
 ```sh
-sudo unshare -m "umount /etc; ls -lahR /etc"
+sudo unshare -m sh -c "umount /etc; ls -lahR /etc"
 ```
 
 ### Configure a post-install update hook


### PR DESCRIPTION
- sysext: Add debugging commands
    
    When unsure what files an image ships or why the image is not compatible
    it can help to list the image contents or show the debug output from the
    matching.
- Correct unshare mount command for listing /etc
    
    Unshare expects a single command with arguments but the "sh -c" was
    forgotten here.

## How to use


## Testing done

Ran the command for the docker compose image.
